### PR TITLE
fix(config): correct CORS mapping and allowed methods

### DIFF
--- a/src/main/java/com/uni/kitcheniq/config/CorsConfig.java
+++ b/src/main/java/com/uni/kitcheniq/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.uni.kitcheniq.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/*")
+                        .allowedOrigins("http://localhost:5173")
+                        .allowedMethods("")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}
+

--- a/src/main/java/com/uni/kitcheniq/config/SecurityConfig.java
+++ b/src/main/java/com/uni/kitcheniq/config/SecurityConfig.java
@@ -28,10 +28,6 @@ public class SecurityConfig {
                         authRequest
                                 // Añadir barras iniciales en los patrones
                                 .requestMatchers("/kitcheniq/api/v1/auth/**").permitAll()
-                                .requestMatchers("/kitcheniq/api/v1/order/**").permitAll()
-                                .requestMatchers("/kitcheniq/api/v1/menu/**").permitAll()
-                                .requestMatchers("/kitcheniq/api/v1/demo/**").permitAll()
-                                .requestMatchers("/kitcheniq/api/v1/orders/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement ->


### PR DESCRIPTION
This pull request introduces a new CORS configuration and tightens security by restricting public access to several API endpoints. The most important changes are summarized below:

**CORS Configuration:**

* Added a new `CorsConfig` class to configure CORS settings, allowing requests from `http://localhost:5173` with credentials and all headers, but with an empty list of allowed HTTP methods (which may be a misconfiguration). (`src/main/java/com/uni/kitcheniq/config/CorsConfig.java`)

**Security Configuration:**

* Removed public (permitAll) access to the `/kitcheniq/api/v1/order/**`, `/kitcheniq/api/v1/menu/**`, `/kitcheniq/api/v1/demo/**`, and `/kitcheniq/api/v1/orders/**` endpoints, making them require authentication. (`src/main/java/com/uni/kitcheniq/config/SecurityConfig.java`)